### PR TITLE
Gradle의 Test 결과 로그가 바로 Console에 출력되도록 설정

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ jdk:
 install: false
 
 env:
+  global:
+    - TERM=dumb
   matrix:
-    - PROFILE=development
+    PROFILE=development
 
 script:
   - ./gradlew clean build -Dspring.profiles.active=${PROFILE}


### PR DESCRIPTION
Gradle의 Test 결과 로그가 바로 Console에 출력되도록 설정함.

[Stackoverflow 답변](http://stackoverflow.com/questions/17942819/how-can-i-get-clean-gradle-output-on-travis-ci)
